### PR TITLE
Use `mongod` service for deb/ubuntu builds

### DIFF
--- a/llv2_build.sh
+++ b/llv2_build.sh
@@ -709,7 +709,10 @@ function debian_mongo ()
             apt-get update >> $OUTPUT_LOG 2>>$ERROR_LOG
             apt-get install mongodb-org >> $OUTPUT_LOG 2>>$ERROR_LOG
             systemctl unmask mongodb
-            service mongodb start
+            # Attempt to start via both services - one will likely fail but 
+            output "Attempting to start mongod service...."
+            output" If this fails you will need to check how the Mongo service is setup for your system and manually start it"
+            service mongod start
         fi
     else
         output "installing mongodb...." true


### PR DESCRIPTION
Not 100% this is actually correct, but certainly for a stock EC2 Ubuntu 16.04 instance it should be `mongod`