### PR TITLE
Fix ClamAV warning about missing clamd.conf file

### DIFF
--- a/llv2_build.sh
+++ b/llv2_build.sh
@@ -829,7 +829,7 @@ function redhat_clamav ()
 function redhat_install ()
 {
     output "installing base software...." true
-    yum -y install curl git python make automake gcc gcc-c++ kernel-devel xorg-x11-server-Xvfb git-core >> $OUTPUT_LOG 2>>$ERROR_LOG &
+    yum -y install curl wget git python make automake gcc gcc-c++ kernel-devel xorg-x11-server-Xvfb git-core >> $OUTPUT_LOG 2>>$ERROR_LOG &
     print_spinner true
 
     if [[ ! `command -v pwmake` ]]; then

--- a/llv2_build.sh
+++ b/llv2_build.sh
@@ -766,7 +766,7 @@ function debian_redis ()
 function debian_clamav ()
 {
     output "Installing ClamAV...." true
-    apt-get -y -qq install clamav >> $OUTPUT_LOG 2>>$ERROR_LOG &
+    apt-get -y -qq install clamav clamav-daemon >> $OUTPUT_LOG 2>>$ERROR_LOG &
     print_spinner true
     CLAM_INSTALLED=true
 }


### PR DESCRIPTION
Installing just the clamav package doesn't install clamav-daemon, so the conf file is missing. This fix adds clamav-daemon to the learninglocker deploy script.
Details: https://askubuntu.com/questions/589318/freshclam-error-clamd-conf-file-not-found/632911

Example error log in /var/log/clamav/frashclam.log on Ubuntu 16.04.3:

```
Mon Nov 20 08:25:28 2017 -> Received signal: wake up
Mon Nov 20 08:25:28 2017 -> ClamAV update process started at Mon Nov 20 08:25:28 2017
Mon Nov 20 08:25:28 2017 -> main.cvd is up to date (version: 58, sigs: 4566249, f-level: 60, builder: sigmgr)
Mon Nov 20 08:25:59 2017 -> nonblock_recv: recv timing out (30 secs)
Mon Nov 20 08:25:59 2017 -> WARNING: getfile: Error while reading database from db.local.clamav.net (IP: 104.131.196.175): Operation now in progress
Mon Nov 20 08:25:59 2017 -> WARNING: getpatch: Can't download daily-24058.cdiff from db.local.clamav.net
Mon Nov 20 08:26:00 2017 -> Downloading daily-24058.cdiff [100%]
Mon Nov 20 08:26:02 2017 -> daily.cld updated (version: 24058, sigs: 1785257, f-level: 63, builder: neo)
Mon Nov 20 08:26:03 2017 -> bytecode.cld is up to date (version: 318, sigs: 75, f-level: 63, builder: raynman)
Mon Nov 20 08:26:06 2017 -> Database updated (6351581 signatures) from db.local.clamav.net (IP: 150.214.142.197)
Mon Nov 20 08:26:06 2017 -> ERROR: NotifyClamd: Can't find or parse configuration file /etc/clamav/clamd.conf
Mon Nov 20 08:26:06 2017 -> --------------------------------------
```
