### PR TITLE
fix: Fix CLAMDSCAN_CONF env var substitution for LOCAL INSTALL section (LLC-2459)

### DIFF
--- a/deployll.sh
+++ b/deployll.sh
@@ -2121,7 +2121,7 @@ if [[ $LOCAL_INSTALL == true ]] && [[ $UPDATE_MODE == false ]]; then
     if [[ $CLAM_INSTALLED == true ]]; then
         sed -i "s?#CLAMDSCAN_BINARY=/usr/bin/clamscan?CLAMSCAN_BINARY=${CLAM_PATH}?" $LOCAL_PATH/${WEBAPP_SUBDIR}/.env
         find_clam_config
-        sed -i "s?#CLAMDSCAN_CONF=/etc/clamav/clamd.conf?CLAMSCAN_BINARY=${CLAMD_CONFIG}?" $LOCAL_PATH/${WEBAPP_SUBDIR}/.env
+        sed -i "s?#CLAMDSCAN_CONF=/etc/clamav/clamd.conf?CLAMDSCAN_CONF=${CLAMD_CONFIG}?" $LOCAL_PATH/${WEBAPP_SUBDIR}/.env
     fi
 
     # set up symlink

--- a/deployll.sh
+++ b/deployll.sh
@@ -2119,7 +2119,7 @@ if [[ $LOCAL_INSTALL == true ]] && [[ $UPDATE_MODE == false ]]; then
 
     # update the .env with the path to clamav
     if [[ $CLAM_INSTALLED == true ]]; then
-        sed -i "s?#CLAMDSCAN_BINARY=/usr/bin/clamscan?CLAMSCAN_BINARY=${CLAM_PATH}?" $LOCAL_PATH/${WEBAPP_SUBDIR}/.env
+        sed -i "s?#CLAMDSCAN_BINARY=/usr/bin/clamscan?CLAMDSCAN_BINARY=${CLAM_PATH}?" $LOCAL_PATH/${WEBAPP_SUBDIR}/.env
         find_clam_config
         sed -i "s?#CLAMDSCAN_CONF=/etc/clamav/clamd.conf?CLAMDSCAN_CONF=${CLAMD_CONFIG}?" $LOCAL_PATH/${WEBAPP_SUBDIR}/.env
     fi


### PR DESCRIPTION
The `CLAMDSCAN_CONF` env var value substitution command incorrectly renames it to `CLAMDSCAN_BINARY` adding a second definition for this env var.

EDIT:
`CLAMDSCAN_BINARY` also had a mistake in the substitution. It was being renamed to `CLAMSCAN_BINARY` without the `D` after `CLAM`